### PR TITLE
Added NixOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,3 @@
-# ms912x driver for Linux
+# ms912x driver for Nix
 
-Linux kernel driver for MacroSilicon USB to VGA/HDMI adapter.
-
-There are two variants:
- - VID/PID is 534d:6021. Device is USB 2
- - VID/PID is 345f:9132. Device is USB 3
-
-For kernel 6.1 checkout branch kernel-6.1
-
-TODOs:
-
-- Detect connector type (VGA, HDMI, etc...)
-- More resolutions
-- Error handling
-- Is RGB to YUV conversion needed?
-
-## Development 
-
-Driver is written by analyzing wireshark captures of the device.
-
-## DKMS
-
-Run `sudo dkms install .`
-
+Fork of https://github.com/rhgndf/ms912x, Linux kernel driver for MacroSilicon USB to VGA/HDMI adapter, (probably) adapted for Nix package manager.

--- a/ms912x.nix
+++ b/ms912x.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, kernel
+}:
+
+stdenv.mkDerivation rec {
+  name = "ms912x";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "rhgndf";
+    repo = "ms912x";
+    rev = "738aef1";
+    sha256 = "16d2cjnsd9cf482jc7crigq1qsk0g7973dkzrck9b95sfclj7l8n";
+  };
+
+	setSourceRoot = ''
+		export sourceRoot=$(pwd)/source
+	'';
+
+	nativeBuildInputs = kernel.moduleBuildDependencies;
+
+	makeFlags = kernel.makeFlags ++ [
+		"-C"
+		"${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+		"M=$(sourceRoot)"
+	];
+
+  buildFlags = [ "modules" ]; 
+	installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
+  installTargets = [ "modules_install" ];
+
+
+  meta = with lib; {
+    description = "Drivers for MacroSilicon VGA Display Adapter";
+    homepage = "https://github.com/rhgndf/ms912x";
+    license = licenses.gpl2;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
NixOS is declarative, therefore using installing via dkms will break a lot of things (if even possible). So, to use with NixOS this file is required.